### PR TITLE
Initial Meeting Notes

### DIFF
--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -4,6 +4,7 @@
 ### Executive Sponsor
 - Tom Hatch, SaltStack CTO
 ### SaltStack Team Members
+- Derek Ardolf
 - Alyssa Rock
 - Ashley Newton
 - Ken Crowell

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> _This is the SaltStack Documentation Working Group repository. For other working groups,_
+> _checkout the [SaltStack Community](https://github.com/saltstack/community) repository._
+
 # Documentation Working Group
 The purpose of the Documentation Working Group is to improve the overall quality of Salt documentation by:
 - Decreasing the time investment for new users to onboard

--- a/meeting-notes/2020-07-13.md
+++ b/meeting-notes/2020-07-13.md
@@ -1,0 +1,49 @@
+# 2020-07-13 Meeting
+
+## Attendees
+
+* Derek Ardolf
+* Sage Robins
+* Cassandra Faris
+* Gareth Greenway
+* Alyssa Rock
+
+## Meeting Details
+
+### Future of Documentation Working Group
+
+- Need to delegate out responsibilities based on interests
+- Should log who is doing what each quarter, and include in minutes in repo
+- Automated testing goals:
+  - Linkchecks
+  - Spelling
+  - Potentially implement something like rstcheck?
+
+### Process for New Working Group Meetings
+
+- Post to the #Documentation / #Announcements channels leading up to working group
+- The notes/minutes need to be posted to the DocsHub repo
+  - People who are watching the repository will be able to see updates in their feed
+
+### Documentation Path Surveying?
+
+- Discussed the potential of a survey: Welcome! What are you using Salt for?
+  - Different reasons could provide feedback on how to better improve the docs based on:
+    - SysAdmins / SysEngs
+    - InfoSec / Incident Response
+    - Other misc. paths  
+- Google Analytics / Reports for Open Docs: Would love to take a look at how the docs are used
+  - Need to reach out to SaltStack marketing team about analytics, and what we can learn
+
+- Can we have a "formal" process for people to join the WG (subscription/newsletter)? This has been asked before, and we may want to implement something
+
+## Clinic and Docs Jam
+
+- Docs clinic in August: Tentative date of August 26th, 2020 (1hr)
+- Docs Jam in September, after Labor Day: Tentative date of September 9th, 2020
+- For docs clinic and docs jam process, should consult Alyssa on how 2019 workshop went
+
+### Clinic ideas
+
+- Towncrier: Making a good changelog entry
+- Docstrings: Making nicely documented functions

--- a/meeting-notes/2020-07-13.md
+++ b/meeting-notes/2020-07-13.md
@@ -47,3 +47,15 @@
 
 - Towncrier: Making a good changelog entry
 - Docstrings: Making nicely documented functions
+
+### Assignments or Action Items
+
+- Derek: talk to Ryan in marketing about Google Analytics on Open Docs, if any, if not ask Bryce if Cloud Front data exists, agenda for next week's WG session will be to plan the Aug Clinic and Sep Doc Jam
+- Alyssa: take on communications, meeting minutes, agendas, reminders, and work with Cassandra on a Working Group Communication Plan, next WG session with Sage put together a Roles and Responsibilities outline, review, briefly
+- Sage: help Working Group with Project Management and Release Management as a role
+
+### Decisions
+
+- Alan will step away from the captain role for a while, he will still be involved. Derek will over this role, and responsibilities will divided among the entire group and rotated often so no one does a lot.
+- Meeting minutes will be kept in the docs-hub repo
+- Review the need to mirror issues from other repos into this repo - may not be needed with Derek heading up the captain role, does it provide value, if so, can it be automated?


### PR DESCRIPTION
- Creating a subdirectory for meeting notes, using the [wg_SSH/meeting-notes](https://github.com/saltstack/community/tree/master/working_groups/wg-SSH/meeting-notes) notes as a reference
- Added linkback to the other working groups and community repository
- Add Derek to the SaltStack Team list

These initial notes are from a meeting about the documentation working group rather than the usual working group meeting, as part of planning how to best go about running it and other related events (such as potential docs clinics and docs jams).