### PR TITLE
Agenda for docs working group on 2020-09-17

### DIFF
--- a/meeting-notes/2020-09-17.md
+++ b/meeting-notes/2020-09-17.md
@@ -2,7 +2,12 @@
 
 ## Attendees
 
-* TBD
+* Derek Ardolf
+* Casandra Faris
+* Gareth Greenaway
+* Ashley Newton
+* Dave Boucha
+* Alyssa Rock
 
 ## Meeting details
 
@@ -12,20 +17,30 @@
 - The full day documentation jam will be held October 7 from 8-5 MDT.
 - The next Docs working group meeting is October 1.
 
-### Collaboration with SaltStack training
-
-- Follow up on action items:
-  - Sage will initiate a conversation with SaltStack's training specialist
-    Adam Cannon to talk about how the Open Docs working group can collaborate
-    with training to potentially provide public access to some of the high
-    quality materials we have for learning about Salt.
-
 ### First documentation clinic
 
-- Follow up on action items:
-  - Derek will schedule a dry run of the first docs testing clinic for next week
-    or the following with Cassandra, Sage, Alyssa, and potentially others.
-    SaltStack employees to figure out how long the process might take.
+- The internal docs clinic is scheduled for next week.
+- For the internal docs jam, we want to ensure that Derek, Cassandra, Alyssa,
+  and at least one core member is present.
+- Content of the first docs jam:
+  - Walk throguh the prerequisites and links for how to learn more:
+    - How to set up Git and GitHub
+    - How to set up GPG signing
+  - How to find the core documentation and how to find the module documentation
+    in the docstrings
+  - How to open a docs issue
+  - How to make a change through Github
+  - How to make a change in the repo and submit a PR
+- Action items:
+  - Alyssa will begin a draft of how to write a good docs issue for this sprint.
+
+### Revise the contributing guide
+
+- Derek would like to have the contributing guide in a good state prior to the
+  first community docs clinic or at least before the documentation jam.
+- We have various guides, such as:
+  - [Contributing Guide (Salt Docs)](https://docs.saltstack.com/en/latest/topics/development/contributing.html)
+  - [Contributing Guide (GitHub)](https://github.com/saltstack/salt/blob/master/.github/CONTRIBUTING.md)
 
 ### Docs jam planning
 
@@ -33,19 +48,15 @@
   - First documentation clinic how-to video and supporting guides
   - Docs jam agenda (already complete)
   - Schedule for the docs jam Zoom room hosts
-- Follow up on action items:
-  - Cassandra will ensure the docs jam is scheduled
-  - Cassandra will develop the Zoom room host schedule closer to the doc jam
-    date
-  - Alyssa will ask Erin McKean from the Google open source advocacy division to
-    see if she'd be interested in speaking about the value of docs for open
-    source.
+- Erin McKean from the Google open source advocacy division will speak at the
+  docs jam. Alyssa will get an official title and job description from her.
 
-### Duplicating tickets to docs-hub using the Github API script
+### Supporting documentation for Idem and other Salt-related open sourc projects
 
-- Follow up on action items:
-  - Sage will create a first draft of a list of requirements for us to review
-    in the next working group meeting.
+- Derek and Dave Boucha will meet to brainstorm ideas for ensuring that the
+  documentation for these projects starts out moving in the right direction. We
+  want to ensure that the standards and habits that develop early on are
+  productive and healthy.
 
 ### Salt Glossary and The Glossarist
 

--- a/meeting-notes/2020-09-17.md
+++ b/meeting-notes/2020-09-17.md
@@ -1,0 +1,55 @@
+# 2020-09-17 meeting
+
+## Attendees
+
+* TBD
+
+## Meeting details
+
+### Dates of note
+
+- The first docs clinic will be held September 30.
+- The full day documentation jam will be held October 7 from 8-5 MDT.
+- The next Docs working group meeting is October 1.
+
+### Collaboration with SaltStack training
+
+- Follow up on action items:
+  - Sage will initiate a conversation with SaltStack's training specialist
+    Adam Cannon to talk about how the Open Docs working group can collaborate
+    with training to potentially provide public access to some of the high
+    quality materials we have for learning about Salt.
+
+### First documentation clinic
+
+- Follow up on action items:
+  - Derek will schedule a dry run of the first docs testing clinic for next week
+    or the following with Cassandra, Sage, Alyssa, and potentially others.
+    SaltStack employees to figure out how long the process might take.
+
+### Docs jam planning
+
+- The pieces that we need to have in place for the docs jam:
+  - First documentation clinic how-to video and supporting guides
+  - Docs jam agenda (already complete)
+  - Schedule for the docs jam Zoom room hosts
+- Follow up on action items:
+  - Cassandra will ensure the docs jam is scheduled
+  - Cassandra will develop the Zoom room host schedule closer to the doc jam
+    date
+  - Alyssa will ask Erin McKean from the Google open source advocacy division to
+    see if she'd be interested in speaking about the value of docs for open
+    source.
+
+### Duplicating tickets to docs-hub using the Github API script
+
+- Follow up on action items:
+  - Sage will create a first draft of a list of requirements for us to review
+    in the next working group meeting.
+
+### Salt Glossary and The Glossarist
+
+- Alyssa is exploring the idea of creating a Salt Glossary using the open source
+  tool The Glossarist. It can output into JSON format among other formats.
+
+### Next docs working group meeting: October 1


### PR DESCRIPTION
This is the current agenda for the upcoming Docs working group on September 17. Feel free to comment if you'd like to add something to the agenda!